### PR TITLE
Fix forecast api URL

### DIFF
--- a/weatherunderground.js
+++ b/weatherunderground.js
@@ -43,7 +43,7 @@ var adapter = utils.adapter({
 });
 
 function getWuForecastData(cb) {
-    var url = "http://api.wunderground.com/api/" + adapter.config.apikey + "/lang:" + adapter.config.language + "hourly/q/" + adapter.config.location + ".json";
+    var url = "http://api.wunderground.com/api/" + adapter.config.apikey + "/hourly/lang:" + adapter.config.language + "/q/" + adapter.config.location + ".json";
     adapter.log.debug("calling forecast: " + url);
 
     request({url: url, json: true, encoding: null}, function(error, response, body) {


### PR DESCRIPTION
Aktuell lädt der Adapter keinen Forecast, sondern nur die Current-Conditions

Laut der aktuellen wunderground API-Doku https://www.wunderground.com/weather/api/d/docs?d=data/index&MR=1 muss die URL das "feature"  `hourly` enthalten.

Mit der angepassten URL läuft der Adapter wieder einwandfrei.
Vielen Dank!
