### PR TITLE
make sure "precip" values are always integers

### DIFF
--- a/io-package.json
+++ b/io-package.json
@@ -1,9 +1,14 @@
 {
     "common": {
         "name":                     "weatherunderground",
-        "version":                  "1.0.1",
+        "version":                  "1.0.2",
 		"news": {
-			"1.0.1": {
+            "1.0.2": {
+                "en": "make sure precip values are always integers",
+                "de": "make sure precip values are always integers",
+                "ru": "make sure precip values are always integers"
+            },
+            "1.0.1": {
                 "en": "conversion from feet to meter for observation_location",
                 "de": "conversion from feet to meter for observation_location",
                 "ru": "conversion from feet to meter for observation_location"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "iobroker.weatherunderground",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "description": "weatherunderground forecast",
   "author": "Daniel Schaedler <daniel.schaedler@gmail.com>",
   "contributors": [],

--- a/weatherunderground.js
+++ b/weatherunderground.js
@@ -159,8 +159,8 @@ function getWuConditionsData() {
                     adapter.setState("current.visibility_km", {ack: true, val: parseFloat(body.current_observation.visibility_km)});
                     adapter.setState("current.solarradiation", {ack: true, val: body.current_observation.solarradiation});
                     adapter.setState("current.UV", {ack: true, val: parseFloat(body.current_observation.UV)});
-                    adapter.setState("current.precip_1hr_metric", {ack: true, val: (parseInt(body.current_observation.precip_1hr_metric, 10) || 0)});
-                    adapter.setState("current.precip_today_metric", {ack: true, val: (parseInt(body.current_observation.precip_today_metric, 10) || 0)});
+                    adapter.setState("current.precip_1hr_metric", {ack: true, val: (isNaN(parseInt(body.current_observation.precip_1hr_metric, 10)) ? null : parseInt(body.current_observation.precip_1hr_metric, 10))});
+                    adapter.setState("current.precip_today_metric", {ack: true, val: (isNaN(parseInt(body.current_observation.precip_today_metric, 10)) ? null : parseInt(body.current_observation.precip_today_metric, 10))});
                     adapter.setState("current.icon_url", {ack: true, val: body.current_observation.icon_url});
                     adapter.setState("current.forecast_url", {ack: true, val: body.current_observation.forecast_url});
                     adapter.setState("current.history_url", {ack: true, val: body.current_observation.history_url});

--- a/weatherunderground.js
+++ b/weatherunderground.js
@@ -159,8 +159,8 @@ function getWuConditionsData() {
                     adapter.setState("current.visibility_km", {ack: true, val: parseFloat(body.current_observation.visibility_km)});
                     adapter.setState("current.solarradiation", {ack: true, val: body.current_observation.solarradiation});
                     adapter.setState("current.UV", {ack: true, val: parseFloat(body.current_observation.UV)});
-                    adapter.setState("current.precip_1hr_metric", {ack: true, val: parseInt(body.current_observation.precip_1hr_metric, 10)});
-                    adapter.setState("current.precip_today_metric", {ack: true, val: parseInt(body.current_observation.precip_today_metric, 10)});
+                    adapter.setState("current.precip_1hr_metric", {ack: true, val: (parseInt(body.current_observation.precip_1hr_metric, 10) || 0)});
+                    adapter.setState("current.precip_today_metric", {ack: true, val: (parseInt(body.current_observation.precip_today_metric, 10) || 0)});
                     adapter.setState("current.icon_url", {ack: true, val: body.current_observation.icon_url});
                     adapter.setState("current.forecast_url", {ack: true, val: body.current_observation.forecast_url});
                     adapter.setState("current.history_url", {ack: true, val: body.current_observation.history_url});

--- a/weatherunderground.js
+++ b/weatherunderground.js
@@ -159,8 +159,8 @@ function getWuConditionsData() {
                     adapter.setState("current.visibility_km", {ack: true, val: parseFloat(body.current_observation.visibility_km)});
                     adapter.setState("current.solarradiation", {ack: true, val: body.current_observation.solarradiation});
                     adapter.setState("current.UV", {ack: true, val: parseFloat(body.current_observation.UV)});
-                    adapter.setState("current.precip_1hr_metric", {ack: true, val: body.current_observation.precip_1hr_metric});
-                    adapter.setState("current.precip_today_metric", {ack: true, val: body.current_observation.precip_today_metric});
+                    adapter.setState("current.precip_1hr_metric", {ack: true, val: parseInt(body.current_observation.precip_1hr_metric, 10)});
+                    adapter.setState("current.precip_today_metric", {ack: true, val: parseInt(body.current_observation.precip_today_metric, 10)});
                     adapter.setState("current.icon_url", {ack: true, val: body.current_observation.icon_url});
                     adapter.setState("current.forecast_url", {ack: true, val: body.current_observation.forecast_url});
                     adapter.setState("current.history_url", {ack: true, val: body.current_observation.history_url});


### PR DESCRIPTION
… because at day-change 0:00 sometimes "--" is delivered by the API
which may break type consistency and produce conflicts in InfluxDB (at
least)
