### PR TITLE
reworked last fix

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,9 @@ http://forum.iobroker.org/viewtopic.php?f=20&t=2042&sid=a863d19838bc49439759bef8
 There is a still a problem with encoding. The addresses with "äüöß" will be shown wrong.
 
 # changelog
+## 1.0.2 (2016-10-29)
+* (Apollon77) make sure precip values are always integers
+
 ## 1.0.1 (2016-07-21)
 * (jens-maus) conversion from feet to meter for observation_location
 

--- a/weatherunderground.js
+++ b/weatherunderground.js
@@ -159,8 +159,12 @@ function getWuConditionsData() {
                     adapter.setState("current.visibility_km", {ack: true, val: parseFloat(body.current_observation.visibility_km)});
                     adapter.setState("current.solarradiation", {ack: true, val: body.current_observation.solarradiation});
                     adapter.setState("current.UV", {ack: true, val: parseFloat(body.current_observation.UV)});
-                    adapter.setState("current.precip_1hr_metric", {ack: true, val: (isNaN(parseInt(body.current_observation.precip_1hr_metric, 10)) ? null : parseInt(body.current_observation.precip_1hr_metric, 10))});
-                    adapter.setState("current.precip_today_metric", {ack: true, val: (isNaN(parseInt(body.current_observation.precip_today_metric, 10)) ? null : parseInt(body.current_observation.precip_today_metric, 10))});
+                    if (!isNaN(parseInt(body.current_observation.precip_1hr_metric, 10))) {
+                        adapter.setState("current.precip_1hr_metric", {ack: true, val: parseInt(body.current_observation.precip_1hr_metric, 10)});
+                    }
+                    if (!isNaN(parseInt(body.current_observation.precip_today_metric, 10))) {
+                        adapter.setState("current.precip_today_metric", {ack: true, val: parseInt(body.current_observation.precip_today_metric, 10)});
+                    }
                     adapter.setState("current.icon_url", {ack: true, val: body.current_observation.icon_url});
                     adapter.setState("current.forecast_url", {ack: true, val: body.current_observation.forecast_url});
                     adapter.setState("current.history_url", {ack: true, val: body.current_observation.history_url});


### PR DESCRIPTION
- javascript adapter don’t like „null“ values … so better only write
  the state when the value is valid
