### PR TITLE
fixed invalid time source for hourly forecast

### DIFF
--- a/main.js
+++ b/main.js
@@ -1363,7 +1363,7 @@ function parseNewResult(body, cb) {
                 try {
                     adapter.setState('forecastHourly.' + i + 'h.time', {
                         ack: true,
-                        val: new Date(body.hourly_forecast.expirationTimeUtc[i] * 1000).toLocaleString()
+                        val: new Date(body.hourly_forecast.validTimeUtc[i] * 1000).toLocaleString()
                     });
                     adapter.setState('forecastHourly.' + i + 'h.temp', {
                         ack: true,

--- a/main.js
+++ b/main.js
@@ -802,7 +802,7 @@ function parseLegacyResult(body, cb) {
                     // see http://www.wunderground.com/weather/api/d/docs?d=resources/phrase-glossary for infos about properties and codes
                     adapter.setState('forecastHourly.' + i + 'h.time', {
                         ack: true,
-                        val: new Date(Date.UTC(parseInt(body.hourly_forecast.validTimeUtc[i], 10) * 1000)).toLocaleString()
+                        val: new Date(parseInt(body.hourly_forecast.validTimeUtc[i], 10) * 1000).toString()
                     });
                     adapter.setState('forecastHourly.' + i + 'h.temp', {
                         ack: true,
@@ -1363,7 +1363,7 @@ function parseNewResult(body, cb) {
                 try {
                     adapter.setState('forecastHourly.' + i + 'h.time', {
                         ack: true,
-                        val: new Date(Date.UTC(body.hourly_forecast.validTimeUtc[i] * 1000)).toLocaleString()
+                        val: new Date(body.hourly_forecast.validTimeUtc[i] * 1000).toString()
                     });
                     adapter.setState('forecastHourly.' + i + 'h.temp', {
                         ack: true,

--- a/main.js
+++ b/main.js
@@ -802,7 +802,7 @@ function parseLegacyResult(body, cb) {
                     // see http://www.wunderground.com/weather/api/d/docs?d=resources/phrase-glossary for infos about properties and codes
                     adapter.setState('forecastHourly.' + i + 'h.time', {
                         ack: true,
-                        val: new Date(parseInt(body.hourly_forecast.expirationTimeUtc[i], 10) * 1000).toLocaleString()
+                        val: new Date(parseInt(body.hourly_forecast.validTimeUtc[i], 10) * 1000).toLocaleString()
                     });
                     adapter.setState('forecastHourly.' + i + 'h.temp', {
                         ack: true,

--- a/main.js
+++ b/main.js
@@ -802,7 +802,7 @@ function parseLegacyResult(body, cb) {
                     // see http://www.wunderground.com/weather/api/d/docs?d=resources/phrase-glossary for infos about properties and codes
                     adapter.setState('forecastHourly.' + i + 'h.time', {
                         ack: true,
-                        val: new Date(parseInt(body.hourly_forecast.validTimeUtc[i], 10) * 1000).toLocaleString()
+                        val: new Date(Date.UTC(parseInt(body.hourly_forecast.validTimeUtc[i], 10) * 1000)).toLocaleString()
                     });
                     adapter.setState('forecastHourly.' + i + 'h.temp', {
                         ack: true,
@@ -1363,7 +1363,7 @@ function parseNewResult(body, cb) {
                 try {
                     adapter.setState('forecastHourly.' + i + 'h.time', {
                         ack: true,
-                        val: new Date(body.hourly_forecast.validTimeUtc[i] * 1000).toLocaleString()
+                        val: new Date(Date.UTC(body.hourly_forecast.validTimeUtc[i] * 1000)).toLocaleString()
                     });
                     adapter.setState('forecastHourly.' + i + 'h.temp', {
                         ack: true,


### PR DESCRIPTION
The time source was the expiration time which is not the time the forecast is for. The correct time is in validTimeUtc instead. Fixes #50 
In addition the time was treated as GMT although it is UTC (1 hour shifted depending on adapter time zone)