### PR TITLE
Add visibility index to hourly forecast

### DIFF
--- a/main.js
+++ b/main.js
@@ -1363,7 +1363,7 @@ function parseNewResult(body, cb) {
                 try {
                     adapter.setState('forecastHourly.' + i + 'h.time', {
                         ack: true,
-                        val: new Date(body.hourly_forecast.expirationTimeUtc[i] * 1000).toLocaleString()
+                        val: new Date(body.hourly_forecast.validTimeUtc[i] * 1000).toLocaleString()
                     });
                     adapter.setState('forecastHourly.' + i + 'h.temp', {
                         ack: true,

--- a/main.js
+++ b/main.js
@@ -802,7 +802,7 @@ function parseLegacyResult(body, cb) {
                     // see http://www.wunderground.com/weather/api/d/docs?d=resources/phrase-glossary for infos about properties and codes
                     adapter.setState('forecastHourly.' + i + 'h.time', {
                         ack: true,
-                        val: new Date(Date.UTC(parseInt(body.hourly_forecast.validTimeUtc[i], 10) * 1000)).toLocaleString()
+                        val: new Date(parseInt(body.hourly_forecast.validTimeUtc[i], 10) * 1000).toString()
                     });
                     adapter.setState('forecastHourly.' + i + 'h.temp', {
                         ack: true,
@@ -1363,7 +1363,7 @@ function parseNewResult(body, cb) {
                 try {
                     adapter.setState('forecastHourly.' + i + 'h.time', {
                         ack: true,
-                        val: new Date(Date.UTC(body.hourly_forecast.validTimeUtc[i] * 1000)).toLocaleString()
+                        val: new Date(body.hourly_forecast.validTimeUtc[i] * 1000).toString()
                     });
                     adapter.setState('forecastHourly.' + i + 'h.temp', {
                         ack: true,

--- a/main.js
+++ b/main.js
@@ -1425,7 +1425,7 @@ function parseNewResult(body, cb) {
                         ack: true,
                         val: parseFloat(body.hourly_forecast.visibility[i]) * (nonMetric ? 1 : 1.609)
                     });
-                    adapter.log('Visibility: ' + body.hourly_forecast.visibility[i] + ', multiplier: ' + (nonMetric ? 1 : 1.609), 'info');
+                    adapter.log.info('Visibility: ' + body.hourly_forecast.visibility[i] + ', multiplier: ' + (nonMetric ? 1 : 1.609));
 
                     qpfMax += body.hourly_forecast.qpf[i];
                     uviSum += body.hourly_forecast.uvIndex[i];

--- a/main.js
+++ b/main.js
@@ -802,7 +802,7 @@ function parseLegacyResult(body, cb) {
                     // see http://www.wunderground.com/weather/api/d/docs?d=resources/phrase-glossary for infos about properties and codes
                     adapter.setState('forecastHourly.' + i + 'h.time', {
                         ack: true,
-                        val: new Date(parseInt(body.hourly_forecast.expirationTimeUtc[i], 10) * 1000).toLocaleString()
+                        val: new Date(parseInt(body.hourly_forecast.validTimeUtc[i], 10) * 1000).toLocaleString()
                     });
                     adapter.setState('forecastHourly.' + i + 'h.temp', {
                         ack: true,

--- a/main.js
+++ b/main.js
@@ -1423,9 +1423,8 @@ function parseNewResult(body, cb) {
                     }); // mean sea level pressure
                     adapter.setState('forecastHourly.' + i + 'h.visibility', {
                         ack: true,
-                        val: parseFloat(body.hourly_forecast.visibility[i]) * (nonMetric ? 1 : 1.609)
+                        val: body.hourly_forecast.visibility[i] * (nonMetric ? 1 : 1.609)
                     });
-                    adapter.log.info('Visibility: ' + body.hourly_forecast.visibility[i] + ', multiplier: ' + (nonMetric ? 1 : 1.609));
 
                     qpfMax += body.hourly_forecast.qpf[i];
                     uviSum += body.hourly_forecast.uvIndex[i];

--- a/main.js
+++ b/main.js
@@ -852,7 +852,7 @@ function parseLegacyResult(body, cb) {
                     }); // mean sea level pressure
                     adapter.setState('forecastHourly.' + i + 'h.visibility', {
                         ack: true,
-                        val: parseFloat(body.hourly_forecast.visibility[i]) * (nonMetric ? 1 : 1.609)
+                        val: parseFloat(body.hourly_forecast.visibility[i])
                     });
 
                     qpfMax += Number(body.hourly_forecast.qpf[i]);
@@ -1423,7 +1423,7 @@ function parseNewResult(body, cb) {
                     }); // mean sea level pressure
                     adapter.setState('forecastHourly.' + i + 'h.visibility', {
                         ack: true,
-                        val: body.hourly_forecast.visibility[i] * (nonMetric ? 1 : 1.609)
+                        val: parseFloat(body.hourly_forecast.visibility[i])
                     });
 
                     qpfMax += body.hourly_forecast.qpf[i];

--- a/main.js
+++ b/main.js
@@ -802,7 +802,7 @@ function parseLegacyResult(body, cb) {
                     // see http://www.wunderground.com/weather/api/d/docs?d=resources/phrase-glossary for infos about properties and codes
                     adapter.setState('forecastHourly.' + i + 'h.time', {
                         ack: true,
-                        val: new Date(parseInt(body.hourly_forecast.validTimeUtc[i], 10) * 1000).toLocaleString()
+                        val: new Date(Date.UTC(parseInt(body.hourly_forecast.validTimeUtc[i], 10) * 1000)).toLocaleString()
                     });
                     adapter.setState('forecastHourly.' + i + 'h.temp', {
                         ack: true,
@@ -1363,7 +1363,7 @@ function parseNewResult(body, cb) {
                 try {
                     adapter.setState('forecastHourly.' + i + 'h.time', {
                         ack: true,
-                        val: new Date(body.hourly_forecast.validTimeUtc[i] * 1000).toLocaleString()
+                        val: new Date(Date.UTC(body.hourly_forecast.validTimeUtc[i] * 1000)).toLocaleString()
                     });
                     adapter.setState('forecastHourly.' + i + 'h.temp', {
                         ack: true,

--- a/main.js
+++ b/main.js
@@ -850,6 +850,10 @@ function parseLegacyResult(body, cb) {
                         ack: true,
                         val: parseFloat(body.hourly_forecast.pressureMeanSeaLevel[i])
                     }); // mean sea level pressure
+                    adapter.setState('forecastHourly.' + i + 'h.visibility', {
+                        ack: true,
+                        val: parseFloat(body.hourly_forecast.visibility[i]) * (nonMetric ? 1 : 1.609)
+                    });
 
                     qpfMax += Number(body.hourly_forecast.qpf[i]);
                     uviSum += Number(body.hourly_forecast.uvIndex[i]);
@@ -1417,6 +1421,10 @@ function parseNewResult(body, cb) {
                         ack: true,
                         val: body.hourly_forecast.pressureMeanSeaLevel[i]
                     }); // mean sea level pressure
+                    adapter.setState('forecastHourly.' + i + 'h.visibility', {
+                        ack: true,
+                        val: parseFloat(body.hourly_forecast.visibility[i]) * (nonMetric ? 1 : 1.609)
+                    });
 
                     qpfMax += body.hourly_forecast.qpf[i];
                     uviSum += body.hourly_forecast.uvIndex[i];
@@ -2782,6 +2790,19 @@ function checkWeatherVariables() {
                 },
                 native: {id: id + 'mslp.' + nonMetric ? 'metric' : 'english'}
             });
+            adapter.setObjectNotExists(id + 'visibility', {
+                type: 'state',
+                common: {
+                    name: 'Visibility',
+                    type: 'number',
+                    role: 'value.visibility',
+                    unit: nonMetric ? 'mi' : 'km',
+                    read: true,
+                    write: false
+                },
+                native: {id: id + 'visibility'}
+            });
+            
         }
 
         adapter.setObjectNotExists('forecastHourly.6h.sum.precipitation', {

--- a/main.js
+++ b/main.js
@@ -1425,6 +1425,7 @@ function parseNewResult(body, cb) {
                         ack: true,
                         val: parseFloat(body.hourly_forecast.visibility[i]) * (nonMetric ? 1 : 1.609)
                     });
+                    adapter.log('Visibility: ' + body.hourly_forecast.visibility[i] + ', multiplier: ' + (nonMetric ? 1 : 1.609), 'info');
 
                     qpfMax += body.hourly_forecast.qpf[i];
                     uviSum += body.hourly_forecast.uvIndex[i];
@@ -2795,7 +2796,7 @@ function checkWeatherVariables() {
                 common: {
                     name: 'Visibility',
                     type: 'number',
-                    role: 'value.visibility',
+                    role: 'value.distance.visibility',
                     unit: nonMetric ? 'mi' : 'km',
                     read: true,
                     write: false


### PR DESCRIPTION
Adding the visibility index (miles or km) to the hourly forecast data, fixes #53