### PR TITLE
Revert "[iobroker-bot] Update Node.js version range at test-and-release workflow to 22, 24 and 26"

### DIFF
--- a/.github/workflows/test-and-release.yml
+++ b/.github/workflows/test-and-release.yml
@@ -41,7 +41,7 @@ jobs:
         runs-on: ${{ matrix.os }}
         strategy:
             matrix:
-                node-version: [22.x, 24.x, 26.x]
+                node-version: [22.x, 24.x]
                 os: [ubuntu-latest, windows-latest, macos-latest]
 
         steps:


### PR DESCRIPTION
Reverts iobroker-community-adapters/ioBroker.weatherunderground#470